### PR TITLE
Fixes app crashing with list pagination for all list lists

### DIFF
--- a/src/common/types/api.ts
+++ b/src/common/types/api.ts
@@ -204,6 +204,7 @@ interface MoviesApiFindResponse extends ApiSuccessResponse {
 export type MoviesApiResponse = MoviesApiFindResponse | ApiSuccessResponse | ApiErrorResponse;
 
 export interface LetterboxdListsManagementGetResponse extends ApiSuccessResponse {
+  totalCount: number;
   lists: LetterboxdList[];
 }
 
@@ -215,6 +216,7 @@ export type LetterboxdListsManagementApiResponse = ApiResponse<LetterboxdListsMa
 
 
 export interface LetterboxdListsForUserGetResponse extends ApiSuccessResponse {
+  totalCount: number;
   lists: LetterboxdList[];
 }
 

--- a/src/pages/api/users/[userId]/lists/tracking.ts
+++ b/src/pages/api/users/[userId]/lists/tracking.ts
@@ -1,4 +1,6 @@
+import { FindOptionsWhere } from "typeorm";
 import { LetterboxdListsForUserApiResponse } from "../../../../../common/types/api";
+import { LetterboxdList } from "../../../../../db/entities";
 import { getLetterboxdListsRepository } from "../../../../../db/repositories";
 import { numericQueryParam, singleQueryParam } from "../../../../../lib/queryParams";
 import { createApiRoute } from "../../../../../lib/routes";
@@ -8,8 +10,19 @@ const TrackedListsForUserRoute = createApiRoute<LetterboxdListsForUserApiRespons
     get: async (req, res) => {
       const userId = numericQueryParam(req.query.userId)!
       const sortBy = singleQueryParam(req.query.sortBy) || 'publishDate';
-      const sortDir = singleQueryParam(req.query.sortOrder) || 'DESC';
+      const sortDir = singleQueryParam(req.query.sortDir) || 'DESC';
+      const limit = numericQueryParam(req.query.perPage, 10);
+      const offset = (numericQueryParam(req.query.page, 1) - 1) * limit;
       const LetterboxdListsRepo = await getLetterboxdListsRepository();
+
+      const where: FindOptionsWhere<LetterboxdList> = {
+        trackers: {
+          id: userId
+        }
+      };
+
+      const totalCount = await LetterboxdListsRepo.countBy(where);
+      
       const lists = await LetterboxdListsRepo.find({
         relations: {
           movies: {
@@ -17,16 +30,14 @@ const TrackedListsForUserRoute = createApiRoute<LetterboxdListsForUserApiRespons
                         // I was getting error - Property "title" was not found in "Movie". Make sure your query is correct.
           }
         },
-        where: {
-          trackers: {
-            id: userId
-          }
-        },
+        where,
+        take: limit,
+        skip: offset,
         order: {
           [sortBy]: sortDir
         }
       });
-      res.json({ success: true, lists });
+      res.json({ success: true, lists, totalCount });
     }
   }
 });


### PR DESCRIPTION
App was crashing with JS memory errors, trying to process too many results on the "Explore" lists page. I've added MUI pagination to all of the list tabs, with 20 per page as the default.

<img width="862" alt="Screen Shot 2022-09-14 at 2 45 30 PM" src="https://user-images.githubusercontent.com/159370/190237481-793fca8d-81ae-4fdc-9363-4870397c2c02.png">
