### PR TITLE
Fix mobile layout

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,8 @@ import { PageTemplate } from '../components/PageTemplate';
 import { useRouter } from 'next/router';
 import { Box, Button, Grid, Link, Typography } from '@mui/material';
 import Image from 'next/image';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 const HomePage: NextPage = () => {
   const router = useRouter();
@@ -89,12 +91,6 @@ const HomePage: NextPage = () => {
   );
 }
 
-// filters-for-ratings
-// blindspots
-// stats-1
-// stats-2
-// lists
-
 interface IntroCardOptions {
   alignImage: 'left' | 'right';
   image: {
@@ -107,6 +103,13 @@ interface IntroCardOptions {
 }
 
 function IntroCard({ alignImage, image, text, subtext }: IntroCardOptions) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  if (isMobile) {
+    alignImage = "left";
+  }
+
   const imageSection = (
     <Grid item xs={12} md={7}>
       <Box sx={{ ['& > span']: { 
@@ -128,7 +131,7 @@ function IntroCard({ alignImage, image, text, subtext }: IntroCardOptions) {
   );
 
   return (
-    <Grid container spacing={8} sx={{ mb: 15, display: "flex", alignItems: "center" }}>
+    <Grid container spacing={8} sx={{ mb: isMobile ? 20 : 15, display: "flex", alignItems: "center" }}>
       {alignImage === "left" ? imageSection : textSection}
       {alignImage === "left" ? textSection : imageSection}
     </Grid>


### PR DESCRIPTION
Because the image/text layout alternates left to right on larger layouts, the medium and smaller layouts (usually mobile only) had a strange alternating pattern. 

<img width="729" alt="Screen Shot 2022-09-17 at 11 43 59 AM" src="https://user-images.githubusercontent.com/159370/190865094-17d5e3e8-3dba-4832-8827-aa6da5bb926e.png">

This PR uses the "useMediaQuery" hook to override the left/right alternating if it is in a mobile layout.

<img width="640" alt="Screen Shot 2022-09-17 at 11 45 00 AM" src="https://user-images.githubusercontent.com/159370/190865138-e58f7d56-ed70-411b-b42c-39e79fba1e9c.png">
